### PR TITLE
Remove unnecessary workflow settings

### DIFF
--- a/WebEZ-CLI/scaffold/.github/workflows/deploy.yml
+++ b/WebEZ-CLI/scaffold/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ on:
     # Runs on pushes targeting the default branch
     push:
         branches: [main]
-    pull_request:
-        branches: [main]
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
@@ -30,10 +28,7 @@ jobs:
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: ubuntu-latest
-        strategy:
-          matrix:
-            node-version: [16.x,18.x,20.x]    
+        runs-on: ubuntu-latest  
         steps:
             - name: Checkout
               uses: actions/checkout@v3


### PR DESCRIPTION
Removes the strategy field (which was deploying three times?) and the deployment on pull requests (we could make a separate workflow for that situation, where it at least runs the linter and tests, but doesn't try to deploy).