### PR TITLE
Fixes for BindCheckedToBoolean

### DIFF
--- a/WebEZ-core/src/bind.decorators.ts
+++ b/WebEZ-core/src/bind.decorators.ts
@@ -634,9 +634,9 @@ export function BindDisabledToBoolean<
  * @export
  * @group Bind Decorators
  * @example
- * //This will check the checkbox with id myCheckbox if the checked property is true
- * @BindCheckedToBoolean("myCheckbox")
- * public checked: boolean = true;
+ * //This will hide the div with id myDiv1 if the visible property is false
+ * @BindVisibleToBoolean("myDiv1")
+ * public visible: boolean = true;
  */
 export function BindVisibleToBoolean<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -649,6 +649,27 @@ export function BindVisibleToBoolean<
 }
 
 /**
+ * @description Decorator to bind the checked/unchecked value of a checkbox input to a boolean
+ * @param id the element to bind the property to
+ * @returns DecoratorCallback
+ * @export
+ * @group Bind Decorators
+ * @example
+ * //This will check the checkbox with id myCheckbox if the checked property is true
+ * @BindCheckedToBoolean("myCheckbox")
+ * public checked: boolean = true;
+ */
+export function BindCheckedToBoolean<
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    This extends EzComponent,
+    Value extends boolean,
+>(id: string) {
+    return BindAttribute(id, "checked", (value: Value) =>
+        value ? "checked" : "",
+    );
+}
+
+/**
  * @description Decorator to bind the value of an element to a number
  * @param id the element to bind the property to
  * @param append an optional string to append to the number before setting the value
@@ -656,7 +677,7 @@ export function BindVisibleToBoolean<
  * @export
  * @group Bind Decorators
  * @example
- * //This will check the checkbox with id myCheckbox if the checked property is true
+ * //This will bind the text (value) of the div with id myDiv1 to the number in value
  * @BindValueToNumber("myDiv1")
  * public value: number = 100;
  */

--- a/WebEZ-core/src/tests/testing_components/test.component.ts
+++ b/WebEZ-core/src/tests/testing_components/test.component.ts
@@ -4,6 +4,7 @@ import {
     BindCSSClass,
     BindCSSClassToBoolean,
     BindDisabledToBoolean,
+    BindCheckedToBoolean,
     BindStyle,
     BindStyleToNumber,
     BindStyleToNumberAppendPx,
@@ -92,6 +93,7 @@ const html = `<div id="child1"></div>
     <option id="opt1" value="1">1</option>
     <option id="opt2" value="2">1</option>
 </select>
+<input type="checkbox" id="bindCheck24" />
 `;
 const css = "";
 
@@ -232,6 +234,9 @@ export class TestComponent extends EzComponent {
 
     @BindVisibleToBoolean("bindDiv23")
     testVisible1: boolean = false;
+
+    @BindCheckedToBoolean("bindCheck24")
+    testChecked1: boolean = true;
 
     constructor() {
         super(html, css);

--- a/WebEZ-core/src/tests/tests/bind.test.ts
+++ b/WebEZ-core/src/tests/tests/bind.test.ts
@@ -277,21 +277,40 @@ describe("WebEZ-Bind", () => {
             toplevel.testInput3 = "testing";
             expect(el4.value).toBe("testing");
         });
-        test("Test Specialty boolean Binders", () => {
-            let el1 = toplevel["shadow"].getElementById(
-                "bindBtn22",
-            ) as HTMLButtonElement;
-            let el2 = toplevel["shadow"].getElementById(
-                "bindDiv23",
-            ) as HTMLElement;
-            expect(toplevel.testDisabled1).toBe(true);
-            expect(el1.disabled).toBeTruthy();
-            toplevel.testDisabled1 = false;
-            expect(el1.disabled).toBeFalsy();
-            expect(toplevel.testVisible1).toBe(false);
-            expect(el2.style.display).toBe("none");
-            toplevel.testVisible1 = true;
-            expect(el2.style.display).toBe("block");
+        describe("Test Specialty boolean Binders", () => {
+            test("BindDisabledToBoolean", () => {
+                let el1 = toplevel["shadow"].getElementById(
+                    "bindBtn22",
+                ) as HTMLButtonElement;
+                expect(toplevel.testDisabled1).toBe(true);
+                expect(el1.disabled).toBeTruthy();
+                toplevel.testDisabled1 = false;
+                expect(el1.disabled).toBeFalsy();
+                toplevel.testDisabled1 = true;
+                expect(el1.disabled).toBeTruthy();
+            });
+            test("BindVisibleToBoolean", () => {
+                let el2 = toplevel["shadow"].getElementById(
+                    "bindDiv23",
+                ) as HTMLElement;
+                expect(toplevel.testVisible1).toBe(false);
+                expect(el2.style.display).toBe("none");
+                toplevel.testVisible1 = true;
+                expect(el2.style.display).toBe("block");
+                toplevel.testVisible1 = false;
+                expect(el2.style.display).toBe("none");
+            });
+            test("BindCheckedToBoolean", () => {
+                let el3 = toplevel["shadow"].getElementById(
+                    "bindCheck24",
+                ) as HTMLInputElement;
+                expect(toplevel.testChecked1).toBe(true);
+                expect(el3.checked).toBeTruthy();
+                toplevel.testChecked1 = false;
+                expect(el3.checked).toBeFalsy();
+                toplevel.testChecked1 = true;
+                expect(el3.checked).toBeTruthy();
+            });
         });
     });
 


### PR DESCRIPTION
The documentation incorrectly referenced BindCheckedToBoolean inside of BindVisibleToBoolean. This patch fixes the docs, and also creates and tests BindCheckedToBoolean. Although I was able to write that binder, this made me realize that the @Change decorator does not handle Checkbox events correctly. Another PR on the way reference that.

(I believe this is correct and can be safely merged, but I only tested it via Jest, didn't actually try it in practice).