### PR TITLE
Error with @Change decorator for checkbox inputs

### DIFF
--- a/WebEZ-core/src/tests/testing_components/test.component.ts
+++ b/WebEZ-core/src/tests/testing_components/test.component.ts
@@ -19,6 +19,7 @@ import {
     Input,
     Timer,
     WindowEvent,
+    ValueEvent,
 } from "../../event.decorators";
 import { TestChild1Component } from "./test-child1.component";
 import { TestChild2Component } from "./test-child2.component";
@@ -107,6 +108,7 @@ export class TestComponent extends EzComponent {
     testVal2: boolean = false;
     testVal3: number = 0;
     testVal4: string = "";
+    testVal5: string = "";
 
     @BindStyle("styleDiv1", "color")
     testStyle1: string = "red";
@@ -287,5 +289,10 @@ export class TestComponent extends EzComponent {
     @WindowEvent("resize")
     windowResize(event: UIEvent) {
         event.preventDefault();
+    }
+
+    @Change("bindCheck24")
+    evtCheck24Change(event: ValueEvent) {
+        this.testVal5 = event.value;
     }
 }

--- a/WebEZ-core/src/tests/tests/coverage.test.ts
+++ b/WebEZ-core/src/tests/tests/coverage.test.ts
@@ -39,6 +39,18 @@ describe("Exceptions and  (out of band testing)", () => {
             expect(toplevel.evtTest).toBeTruthy();
         });
     });
+    describe("Checkbox Event Tests", () => {
+        test("Checkbox Change Event", () => {
+            let toplevel: any = undefined;
+            toplevel = bootstrap<TestComponent>(TestComponent);
+            expect(toplevel).toBeInstanceOf(TestComponent);
+            expect(toplevel.testVal5).toEqual("");
+            toplevel.click("bindCheck24");
+            expect(toplevel.testVal5).toEqual("on");
+            toplevel.click("bindCheck24");
+            expect(toplevel.testVal5).toEqual("");
+        });
+    });
     describe("Resize Event Tests", () => {
         test("onResizeEvent", () => {
             let toplevel: any = undefined;


### PR DESCRIPTION
The @Change decorator does not work correctly with checkbox inputs. The issue comes down with how [JS/HTML expects checkboxes to behave](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes):

- `checked` is a boolean attribute that actually indicates whether the Checkbox element is checked or not
- `value` is a string attribute that holds the text to be associated with the checkbox. If no explicit `value` is given, then the value is always the string `"on"` - *regardless of whether the checkbox is checked or not!*

The idea in HTML is that when you submit a form with checkboxes, the value is either present or not present in the submitted form based on the checkboxes status. The checkbox's value never changes based on its checked status!

Unfortunately, this is a little tricky to fix, but here's my initial ideas:
1. Do some witchcraft to modify `Change` to manipulate `value` into being based on the `checked` attribute instead of the `value` attribute. This would require inspecting `element`'s `type` attribute to see if it is `'checkbox'`, but I think it could work? Then the values might be `"off"` and `"on"`? Or `""` and `"on"` (with `"on"` being replaced with whatever the `value` initially is in HTML).
2. Do something weird to allow `ValueEvent` to have a `checked` field in certain circumstances? I'm not even sure this is possible, let alone a good idea.
3. Allow `Change` to accept either a `ValueEvent` or a `CheckEvent`, and dispatch the correct one via overloading, somehow.
4. Make a separate `Checked` event decorator and `CheckEvent` parameter, with a `checked` field instead of a `value` field.
5. Tell people to never use `Change` with Checkboxes, just use `Click` and manage the state yourself (but what about `getValue`?)

These all have drawbacks. I'd be interested in your thoughts on solving the issue, perhaps there's something clever I'm not seeing. But I think that the first one would be the easiest for students at least.