### PR TITLE
BindValue of checkbox with checked, instead of BindAttribute

### DIFF
--- a/WebEZ-core/src/bind.decorators.ts
+++ b/WebEZ-core/src/bind.decorators.ts
@@ -599,6 +599,8 @@ export function BindValue<This extends EzComponent, Value>(
                     value,
                 );
                 element.value = transform.call(this, value);
+            } else if (element instanceof HTMLInputElement && element.getAttribute("type") === "checkbox") {
+                (element as HTMLInputElement).checked = transform.call(this, value) === "on";
             } else if (value !== undefined) {
                 if (elementHasValue(element))
                     (element as HTMLInputElement).value = transform.call(
@@ -621,6 +623,8 @@ export function BindValue<This extends EzComponent, Value>(
                             (element as HTMLButtonElement).innerHTML =
                                 transform.call(this, value);
                             element.value = transform.call(this, value);
+                        } else if (element instanceof HTMLInputElement && element.getAttribute("type") === "checkbox") {
+                            (element as HTMLInputElement).checked = transform.call(this, value) === "on";
                         } else if (elementHasValue(element))
                             (element as HTMLInputElement).value =
                                 transform.call(this, value);
@@ -641,6 +645,8 @@ export function BindValue<This extends EzComponent, Value>(
                             (element as HTMLButtonElement).innerHTML =
                                 transform.call(this, value);
                             element.value = transform.call(this, value);
+                        } else if (element instanceof HTMLInputElement && element.getAttribute("type") === "checkbox") {
+                            (element as HTMLInputElement).checked = transform.call(this, value) === "on";
                         } else if (elementHasValue(element))
                             (element as HTMLInputElement).value =
                                 transform.call(this, value);
@@ -941,8 +947,8 @@ export function BindCheckedToBoolean<
     This extends EzComponent,
     Value extends boolean,
 >(id: string) {
-    return BindAttribute(id, "checked", (value: Value) =>
-        value ? "checked" : "",
+    return BindValue(id, (value: Value) =>
+        value ? "on" : "",
     );
 }
 

--- a/WebEZ-core/src/tests/testing_components/test.component.ts
+++ b/WebEZ-core/src/tests/testing_components/test.component.ts
@@ -95,6 +95,7 @@ const html = `<div id="child1"></div>
     <option id="opt2" value="2">1</option>
 </select>
 <input type="checkbox" id="bindCheck24" />
+<input type="checkbox" id="bindCheck25" />
 `;
 const css = "";
 
@@ -241,6 +242,9 @@ export class TestComponent extends EzComponent {
     
     testVal5: string = "";
 
+    @BindCheckedToBoolean("bindCheck25")
+    testChecked2: boolean = true;
+
     constructor() {
         super(html, css);
         this.addComponent(this.child1, "child1");
@@ -294,5 +298,9 @@ export class TestComponent extends EzComponent {
     @Change("bindCheck24")
     evtCheck24Change(event: ValueEvent) {
         this.testVal5 = event.value;
+    }
+    @Change("bindCheck25")
+    evtCheck25Change(event: ValueEvent) {
+        this.testChecked2 = event.value === "on";
     }
 }

--- a/WebEZ-core/src/tests/tests/bind.test.ts
+++ b/WebEZ-core/src/tests/tests/bind.test.ts
@@ -312,6 +312,25 @@ describe("WebEZ-Bind", () => {
                 toplevel.testChecked1 = true;
                 expect(el3.checked).toBeTruthy();
             });
+            test("BindCheckedToBoolean clicking", () => {
+                let el4 = toplevel["shadow"].getElementById(
+                    "bindCheck25",
+                ) as HTMLInputElement;
+                expect(toplevel.testChecked2).toBe(true);
+                expect(el4.checked).toBeTruthy();
+                // Simulate click to change checked status
+                el4.click();
+                expect(el4.checked).toBeFalsy();
+                expect(toplevel.testChecked2).toBe(false);
+                el4.click();
+                expect(el4.checked).toBeTruthy();
+                expect(toplevel.testChecked2).toBe(true);
+                // Should still be able to control the value
+                toplevel.testChecked2 = false;
+                expect(el4.checked).toBeFalsy();
+                toplevel.testChecked2 = true;
+                expect(el4.checked).toBeTruthy();
+            });
         });
     });
 


### PR DESCRIPTION
I *believe* this will fix issue #20 , based on the new passing test case I have provided. It makes `BindCheckedToBoolean` use `BindValue` instead of `BindAttribute("checked")`, since the latter is only modifying the HTML attribute `checked` (which operates at the "IDL" level, rather than the actual DOM value) instead of the JS property checked. In other words, it wasn't really controlling it, even when the attribute got updated. Most of the time, the JS and HTML line up, but apparently all rules go out the window with checkboxes.

This also requires a modification to `BindValue` to handle the case for the checkbox (which is an `HTMLInputElement` with a specific `type`). I guess this could have gone into `BindAttribute`, but there's already logic in `BindValue` for differentiating such things, and I think this ends up making sense (the `checked` attribute is more the checkboxes `value` than its actual `value`). But I'm open to moving it elsewhere.

Probably needs to be tested on a live site still.